### PR TITLE
Remove body-parser dependency and use Express built-in JSON middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
             "license": "MIT",
             "dependencies": {
                 "async-mutex": "^0.5.0",
-                "body-parser": "^2.2.0",
                 "discord.js": "^14.14.1",
                 "express": "^5.1.0",
                 "knex": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     },
     "dependencies": {
         "async-mutex": "^0.5.0",
-        "body-parser": "^2.2.0",
         "discord.js": "^14.14.1",
         "express": "^5.1.0",
         "knex": "^3.1.0",

--- a/src/features/interactions/notify/webhook.bf.ts
+++ b/src/features/interactions/notify/webhook.bf.ts
@@ -1,6 +1,5 @@
 import { Server } from "http";
 import express from "express";
-import bodyParser from "body-parser";
 import { EmbedBuilder } from "@discordjs/builders";
 import { WEBHOOK_TOKEN as TOKEN } from "@/config";
 import { Bot, BotFeature } from "@/types";
@@ -47,7 +46,7 @@ const notify_subscribers = async (p: NotifyParams) => {
 }
 
 const app = express();
-app.use(bodyParser.json());
+app.use(express.json());
 
 
 let server: Server | null = null;


### PR DESCRIPTION
This PR removes the unnecessary `body-parser` dependency and replaces it with Express's built-in `express.json()` middleware, which provides the same functionality without an additional dependency.

Changes:
- Removed `body-parser` from package.json
- Updated webhook.bf.ts to use `express.json()` instead of body-parser
- Updated package-lock.json accordingly
